### PR TITLE
fix(android): make audio routing lifecycle-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 env:
-  FLUTTER_VERSION: '3.19.0'
+  FLUTTER_VERSION: '3.44.5'
   JAVA_VERSION: '17'
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
         run: flutter pub get
 
       - name: 🔍 Verify formatting
-        run: dart format --output=none --set-exit-if-changed .
+        run: dart format --output=none --set-exit-if-changed lib test
 
       - name: 📊 Analyze project source
         run: flutter analyze
@@ -86,6 +86,11 @@ jobs:
       - name: 🧪 Run Android unit tests
         working-directory: example
         run: flutter test
+
+      - name: 🧪 Run native Android routing tests
+        if: matrix.api-level == 21
+        working-directory: example/android
+        run: ./gradlew :flutter_audio_output:testDebugUnitTest --console=plain
 
       - name: 📱 Enable KVM group perms
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
         default: true
 
 env:
-  FLUTTER_VERSION: '3.19.0'
+  FLUTTER_VERSION: '3.44.5'
 
 jobs:
   # Pre-publish validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0
+
+### Android
+- Use communication-device routing APIs on Android 12 and newer, while retaining legacy fallbacks.
+- Complete route-change futures after the requested device is confirmed, rejected, or times out.
+- Add `release()` to cancel pending changes and clear routing state set through the plugin.
+- Add native routing lifecycle and compatibility tests.
+
 ## 1.0.7
 
 ### 🔧 CI/CD & Infrastructure

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  flutter_audio_output: ^1.0.7
+  flutter_audio_output: ^1.1.0
 ```
 
 ## Usage
@@ -54,7 +54,16 @@ final success = await FlutterAudioOutput.changeToSpeaker();
 if (success) {
   print('Successfully switched to speaker');
 }
+
+// Release routing when it is no longer needed.
+await FlutterAudioOutput.release();
 ```
+
+On Android 12 and newer, route-change futures complete after Android confirms
+the selected communication device, or return `false` if the device is
+unavailable or the request times out. On older Android versions, receiver,
+speaker, and wired-headset routing remains synchronous; Bluetooth completes
+after the SCO connection succeeds or fails.
 
 ### Listen to Audio Device Changes
 
@@ -259,6 +268,14 @@ Switches audio output to Bluetooth audio device (if connected).
 
 ```dart
 Future<bool> changeToBluetooth()
+```
+
+#### `release()`
+Cancels pending route changes and clears routing state set through the plugin.
+This method is currently a no-op on iOS.
+
+```dart
+Future<void> release()
 ```
 
 #### `setListener()`

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,8 +50,18 @@ android {
     lint {
         disable 'InvalidPackage'
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.0"
+    implementation 'androidx.annotation:annotation:1.9.1'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.14.2'
+    testImplementation 'org.robolectric:robolectric:4.14.1'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.itsmurphy.flutter_audio_output">
+    <!-- Required by AudioManager routing APIs. -->
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 </manifest>

--- a/android/src/main/java/com/itsmurphy/flutter_audio_output/AudioChangeReceiver.java
+++ b/android/src/main/java/com/itsmurphy/flutter_audio_output/AudioChangeReceiver.java
@@ -3,16 +3,16 @@ package com.itsmurphy.flutter_audio_output;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
-import android.view.KeyEvent;
+import android.media.AudioManager;
 
 interface AudioEventListener {
     void onChanged();
 }
 
+/** Receives wired-headset changes below API 23, where AudioDeviceCallback is unavailable. */
 public class AudioChangeReceiver extends BroadcastReceiver {
 
-    AudioEventListener audioEventListener;
+    private final AudioEventListener audioEventListener;
 
     public AudioChangeReceiver(final AudioEventListener listener) {
         this.audioEventListener = listener;
@@ -20,14 +20,8 @@ public class AudioChangeReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, final Intent intent) {
-        if (intent.getAction().equals(Intent.ACTION_HEADSET_PLUG)) {
-//            final int state = intent.getIntExtra("state", -1);
+        if (AudioManager.ACTION_HEADSET_PLUG.equals(intent.getAction())) {
             audioEventListener.onChanged();
         }
-//        else if(BluetoothAdapter.ACTION_CONNECTION_STATE_CHANGED.equals(intent.getAction())){
-//            audioEventListener.onChanged();
-//        }else if(BluetoothAdapter.ACTION_STATE_CHANGED.equals(intent.getAction())){
-//            audioEventListener.onChanged();
-//        }
     }
 }

--- a/android/src/main/java/com/itsmurphy/flutter_audio_output/FlutterAudioOutputPlugin.java
+++ b/android/src/main/java/com/itsmurphy/flutter_audio_output/FlutterAudioOutputPlugin.java
@@ -1,17 +1,26 @@
 package com.itsmurphy.flutter_audio_output;
 
-import androidx.annotation.NonNull;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.media.AudioManager;
+import android.media.AudioDeviceCallback;
 import android.media.AudioDeviceInfo;
-import android.content.Context;
+import android.media.AudioManager;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
@@ -20,183 +29,775 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
 /** FlutterAudioOutputPlugin */
-@SuppressWarnings("deprecation")
 public class FlutterAudioOutputPlugin implements FlutterPlugin, MethodCallHandler {
   private static final String TAG = "FlutterAudioOutput";
-  
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
+
+  // Keep these values aligned with the Dart AudioPort enum ordinals.
+  private static final int PORT_UNKNOWN = 0;
+  private static final int PORT_RECEIVER = 1;
+  private static final int PORT_SPEAKER = 2;
+  private static final int PORT_HEADPHONES = 3;
+  private static final int PORT_BLUETOOTH = 4;
+
+  // Bluetooth route establishment can take longer than local routing.
+  private static final long ROUTE_CHANGE_TIMEOUT_MS = 5000;
+  private static final long BLUETOOTH_ROUTE_TIMEOUT_MS = 30000;
+  private static final long SCO_CONNECT_TIMEOUT_MS = 10000;
+
+  private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
   private MethodChannel channel;
   private AudioManager audioManager;
   private Context context;
-  private AudioChangeReceiver audioChangeReceiver;
+
+  // AudioManager routing is process-wide. These fields record only changes
+  // made through this instance; other audio clients must coordinate access.
+  private boolean modifiedAudioSettings;
+  private Integer pluginSetMode;
+
+  private AudioChangeReceiver audioChangeReceiver; // API < 23 fallback
+  private AudioDeviceCallback audioDeviceCallback; // API 23+
+
+  // Only one request may be pending. The generation invalidates callbacks
+  // queued by completed or superseded requests.
+  private int requestGeneration;
+  private Result pendingResult;
+  private Runnable pendingTimeout;
+  // True while an API 31+ selection is awaiting confirmation.
+  private boolean pendingSelectionActive;
+  // A null previous mode means this instance did not own the mode.
+  private boolean pendingModeApplied;
+  private Integer pendingPreviousMode;
+  // Route state captured for rollback of the pending request.
+  private boolean pendingPreviousAudioSettingsModified;
+  private AudioDeviceInfo pendingPreviousCommunicationDevice;
+  private boolean pendingLegacySpeakerphoneApplied;
+  private boolean pendingPreviousSpeakerphoneOn;
+  // Stored as Object so class verification succeeds below API 31.
+  private Object pendingDeviceListener;
+  private BroadcastReceiver scoStateReceiver;
+  // True while this instance owns an unmatched startBluetoothSco() request.
+  private boolean scoStarted;
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-    channel = new MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "flutter_audio_output");
+    channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "flutter_audio_output");
     channel.setMethodCallHandler(this);
     context = flutterPluginBinding.getApplicationContext();
     audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-    
-    // Register audio change receiver
-    audioChangeReceiver = new AudioChangeReceiver(listener);
-    IntentFilter filter = new IntentFilter(Intent.ACTION_HEADSET_PLUG);
-    context.registerReceiver(audioChangeReceiver, filter);
-  }
 
-  private final AudioEventListener listener = new AudioEventListener() {
-    @Override
-    public void onChanged() {
-      if (channel != null) {
-        channel.invokeMethod("inputChanged", 1);
-      }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      audioDeviceCallback = new AudioDeviceCallback() {
+        @Override
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
+          notifyInputChanged();
+        }
+
+        @Override
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
+          notifyInputChanged();
+        }
+      };
+      audioManager.registerAudioDeviceCallback(audioDeviceCallback, mainHandler);
+    } else {
+      // AudioDeviceCallback is unavailable below API 23. Preserve the legacy
+      // wired-headset broadcast on those releases.
+      audioChangeReceiver = new AudioChangeReceiver(this::notifyInputChanged);
+      IntentFilter filter = new IntentFilter(AudioManager.ACTION_HEADSET_PLUG);
+      context.registerReceiver(audioChangeReceiver, filter);
     }
-  };
+  }
 
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-    if (call.method.equals("getPlatformVersion")) {
-      result.success("Android " + android.os.Build.VERSION.RELEASE);
-    } else if (call.method.equals("getCurrentOutput")) {
-      result.success(getCurrentOutput());
-    } else if (call.method.equals("getAvailableInputs")) {
-      result.success(getAvailableInputs());
-    } else if (call.method.equals("changeToReceiver")) {
-      result.success(changeToReceiver());
-    } else if (call.method.equals("changeToSpeaker")) {
-      result.success(changeToSpeaker());
-    } else if (call.method.equals("changeToHeadphones")) {
-      result.success(changeToHeadphones());
-    } else if (call.method.equals("changeToBluetooth")) {
-      result.success(changeToBluetooth());
-    } else {
-      result.notImplemented();
+    switch (call.method) {
+      case "getPlatformVersion":
+        result.success("Android " + Build.VERSION.RELEASE);
+        break;
+      case "getCurrentOutput":
+        result.success(getCurrentOutput());
+        break;
+      case "getAvailableInputs":
+        result.success(getAvailableInputs());
+        break;
+      case "changeToReceiver":
+        changeOutput(PORT_RECEIVER, result);
+        break;
+      case "changeToSpeaker":
+        changeOutput(PORT_SPEAKER, result);
+        break;
+      case "changeToHeadphones":
+        changeOutput(PORT_HEADPHONES, result);
+        break;
+      case "changeToBluetooth":
+        changeOutput(PORT_BLUETOOTH, result);
+        break;
+      case "release":
+        releaseRouting(result);
+        break;
+      default:
+        result.notImplemented();
     }
   }
 
-  private Boolean changeToReceiver() {
-    audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
-    audioManager.stopBluetoothSco();
+  // Route changes
+
+  private void changeOutput(int port, Result result) {
+    // Carry the previous mode baseline across superseded requests. The
+    // successor either establishes a new baseline or restores this one.
+    boolean inheritedRollback = pendingModeApplied;
+    Integer inheritedPreviousMode = pendingPreviousMode;
+    boolean inheritedRouteRollback = pendingSelectionActive;
+    AudioDeviceInfo inheritedPreviousCommunicationDevice =
+        pendingPreviousCommunicationDevice;
+    boolean inheritedPreviousAudioSettingsModified =
+        pendingPreviousAudioSettingsModified;
+    completePendingRequest(false);
+
+    // Validate before changing mode so an unavailable route has no side effects.
+    if (!isRouteAvailable(port)) {
+      if (inheritedRollback) {
+        restoreSettledMode(inheritedPreviousMode);
+      }
+      result.success(false);
+      return;
+    }
+
+    Integer previousMode = inheritedRollback ? inheritedPreviousMode : pluginSetMode;
+    applyAudioMode(port);
+    pendingModeApplied = true;
+    pendingPreviousMode = previousMode;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      changeOutputModern(
+          port,
+          result,
+          inheritedRouteRollback,
+          inheritedPreviousCommunicationDevice,
+          inheritedPreviousAudioSettingsModified);
+    } else {
+      changeOutputLegacy(port, result);
+    }
+  }
+
+  private boolean isRouteAvailable(int port) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      return findCommunicationDevice(port) != null;
+    }
+    switch (port) {
+      case PORT_RECEIVER:
+      case PORT_SPEAKER:
+        return true;
+      case PORT_HEADPHONES:
+        return isWiredHeadsetOn();
+      case PORT_BLUETOOTH:
+        // API 21 and 22 cannot enumerate outputs. SCO completion determines
+        // whether Bluetooth is available.
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+            || legacyIsBluetoothScoOn()
+            || isBluetoothCommunicationAvailable();
+      default:
+        return false;
+    }
+  }
+
+  // Clear only state changed through this instance.
+  private void releaseRouting(Result result) {
+    completePendingRequest(false);
+    if (modifiedAudioSettings) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        audioManager.clearCommunicationDevice();
+      } else {
+        resetLegacyRouting();
+      }
+    }
+    if (pluginSetMode != null) {
+      audioManager.setMode(AudioManager.MODE_NORMAL);
+      pluginSetMode = null;
+    }
+    modifiedAudioSettings = false;
+    result.success(null);
+    notifyInputChanged();
+  }
+
+  @SuppressWarnings("deprecation")
+  private void resetLegacyRouting() {
+    stopScoIfStarted();
     audioManager.setBluetoothScoOn(false);
     audioManager.setSpeakerphoneOn(false);
-    listener.onChanged();
-    return true;
   }
 
-  private Boolean changeToSpeaker() {
-    audioManager.setMode(AudioManager.MODE_NORMAL);
-    audioManager.stopBluetoothSco();
-    audioManager.setBluetoothScoOn(false);
-    audioManager.setSpeakerphoneOn(true);
-    listener.onChanged();
-    return true;
+  // Preserve the 1.x audio-mode policy for compatibility.
+  private void applyAudioMode(int port) {
+    int mode = port == PORT_SPEAKER
+        ? AudioManager.MODE_NORMAL
+        : AudioManager.MODE_IN_COMMUNICATION;
+    audioManager.setMode(mode);
+    pluginSetMode = mode;
   }
 
-  private Boolean changeToHeadphones() {
-    return changeToReceiver();
-  }
-
-  private Boolean changeToBluetooth() {
-    audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
-    audioManager.startBluetoothSco();
-    audioManager.setBluetoothScoOn(true);
-    listener.onChanged();
-    return true;
-  }
-
-  private List<String> getCurrentOutput() {
-    List<String> info = new ArrayList<>();
-    
-    if (audioManager.isSpeakerphoneOn()) {
-      info.add("Speaker");
-      info.add("2");
-    } else if (audioManager.isBluetoothScoOn()) {
-      info.add("Bluetooth");
-      info.add("4");
-    } else if (isWiredHeadsetOn()) {
-      info.add("Headset");
-      info.add("3");
-    } else {
-      info.add("Receiver");
-      info.add("1");
+  @RequiresApi(Build.VERSION_CODES.S)
+  private void changeOutputModern(
+      int port,
+      Result result,
+      boolean inheritedRouteRollback,
+      @Nullable AudioDeviceInfo inheritedPreviousCommunicationDevice,
+      boolean inheritedPreviousAudioSettingsModified) {
+    AudioDeviceInfo target = findCommunicationDevice(port);
+    if (target == null) {
+      // The device disappeared between availability checks. Do not substitute
+      // the platform default, which may be a different route.
+      rollbackPendingMode();
+      result.success(false);
+      return;
     }
-    return info;
+
+    AudioDeviceInfo current = audioManager.getCommunicationDevice();
+    final int targetId = target.getId();
+    if (!inheritedRouteRollback && current != null && current.getId() == targetId) {
+      settlePendingMode();
+      result.success(true);
+      notifyInputChanged();
+      return;
+    }
+
+    pendingResult = result;
+    final int generation = requestGeneration;
+    AudioManager.OnCommunicationDeviceChangedListener listener =
+        new AudioManager.OnCommunicationDeviceChangedListener() {
+          @Override
+          public void onCommunicationDeviceChanged(@Nullable AudioDeviceInfo device) {
+            // Listener removal does not cancel callbacks already queued on
+            // the executor; the generation check rejects stale deliveries.
+            if (device != null && device.getId() == targetId) {
+              completePendingRequest(generation, true);
+            }
+          }
+        };
+    pendingDeviceListener = listener;
+    audioManager.addOnCommunicationDeviceChangedListener(context.getMainExecutor(), listener);
+
+    pendingPreviousAudioSettingsModified = inheritedRouteRollback
+        ? inheritedPreviousAudioSettingsModified
+        : modifiedAudioSettings;
+    pendingPreviousCommunicationDevice = inheritedRouteRollback
+        ? inheritedPreviousCommunicationDevice
+        : current;
+    // Record rollback state before invoking AudioManager so rejection and
+    // exceptions use the same cleanup path.
+    pendingSelectionActive = true;
+    try {
+      if (!audioManager.setCommunicationDevice(target)) {
+        completePendingRequest(generation, false);
+        return;
+      }
+    } catch (RuntimeException e) {
+      Log.w(TAG, "Unable to select communication device: " + e.getMessage());
+      completePendingRequest(generation, false);
+      return;
+    }
+
+    pendingTimeout = () -> {
+      AudioDeviceInfo now = audioManager.getCommunicationDevice();
+      completePendingRequest(generation, now != null && now.getId() == targetId);
+    };
+    mainHandler.postDelayed(
+        pendingTimeout,
+        port == PORT_BLUETOOTH ? BLUETOOTH_ROUTE_TIMEOUT_MS : ROUTE_CHANGE_TIMEOUT_MS);
   }
 
-  private boolean isWiredHeadsetOn() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      AudioDeviceInfo[] audioDevices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
-      for (AudioDeviceInfo deviceInfo : audioDevices) {
-        if (deviceInfo.getType() == AudioDeviceInfo.TYPE_WIRED_HEADPHONES ||
-            deviceInfo.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET) {
-          return true;
+  @RequiresApi(Build.VERSION_CODES.S)
+  @Nullable
+  private AudioDeviceInfo findCommunicationDevice(int port) {
+    List<AudioDeviceInfo> devices = audioManager.getAvailableCommunicationDevices();
+    for (int type : communicationDeviceTypesFor(port)) {
+      for (AudioDeviceInfo device : devices) {
+        if (device.getType() == type) {
+          return device;
         }
       }
-      return false;
+    }
+    return null;
+  }
+
+  // Device types are ordered by selection preference.
+  private static int[] communicationDeviceTypesFor(int port) {
+    switch (port) {
+      case PORT_RECEIVER:
+        return new int[] {AudioDeviceInfo.TYPE_BUILTIN_EARPIECE};
+      case PORT_SPEAKER:
+        return new int[] {AudioDeviceInfo.TYPE_BUILTIN_SPEAKER};
+      case PORT_HEADPHONES:
+        return new int[] {
+          AudioDeviceInfo.TYPE_WIRED_HEADSET,
+          AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+          AudioDeviceInfo.TYPE_USB_HEADSET,
+          AudioDeviceInfo.TYPE_USB_DEVICE
+        };
+      case PORT_BLUETOOTH:
+        return new int[] {
+          AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+          AudioDeviceInfo.TYPE_BLE_HEADSET,
+          AudioDeviceInfo.TYPE_BLE_SPEAKER,
+          AudioDeviceInfo.TYPE_HEARING_AID
+        };
+      default:
+        return new int[0];
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private void changeOutputLegacy(int port, Result result) {
+    switch (port) {
+      case PORT_RECEIVER:
+      case PORT_HEADPHONES:
+        // Legacy Android selects the wired device or earpiece when SCO and
+        // speakerphone routing are disabled.
+        stopScoIfStarted();
+        audioManager.setBluetoothScoOn(false);
+        audioManager.setSpeakerphoneOn(false);
+        modifiedAudioSettings = true;
+        settlePendingMode();
+        result.success(true);
+        notifyInputChanged();
+        break;
+      case PORT_SPEAKER:
+        stopScoIfStarted();
+        audioManager.setBluetoothScoOn(false);
+        audioManager.setSpeakerphoneOn(true);
+        modifiedAudioSettings = true;
+        settlePendingMode();
+        result.success(true);
+        notifyInputChanged();
+        break;
+      case PORT_BLUETOOTH:
+        changeToBluetoothLegacy(result);
+        break;
+      default:
+        result.success(false);
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private void changeToBluetoothLegacy(Result result) {
+    boolean alreadyConnected = audioManager.isBluetoothScoOn();
+    if (alreadyConnected && scoStarted) {
+      // Reuse the SCO reference already held by this instance.
+      settlePendingMode();
+      result.success(true);
+      notifyInputChanged();
+      return;
+    }
+
+    pendingPreviousAudioSettingsModified = modifiedAudioSettings;
+    pendingPreviousSpeakerphoneOn = audioManager.isSpeakerphoneOn();
+    pendingLegacySpeakerphoneApplied = true;
+    audioManager.setSpeakerphoneOn(false);
+
+    pendingResult = result;
+    final int generation = requestGeneration;
+    scoStateReceiver = new BroadcastReceiver() {
+      // Ignore sticky state and trailing disconnects from earlier requests.
+      // A disconnect fails this request only after its own CONNECTING state.
+      private boolean seenConnecting;
+
+      @Override
+      public void onReceive(Context ctx, Intent intent) {
+        if (generation != requestGeneration) {
+          return;
+        }
+        if (isInitialStickyBroadcast()) {
+          return;
+        }
+        int state = intent.getIntExtra(
+            AudioManager.EXTRA_SCO_AUDIO_STATE, AudioManager.SCO_AUDIO_STATE_DISCONNECTED);
+        if (state == AudioManager.SCO_AUDIO_STATE_CONNECTED) {
+          audioManager.setBluetoothScoOn(true);
+          completePendingRequest(generation, true);
+        } else if (state == AudioManager.SCO_AUDIO_STATE_CONNECTING) {
+          seenConnecting = true;
+        } else if (state == AudioManager.SCO_AUDIO_STATE_DISCONNECTED && seenConnecting) {
+          completePendingRequest(generation, false);
+        }
+      }
+    };
+    Intent stickyState = context.registerReceiver(
+        scoStateReceiver, new IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED));
+
+    pendingTimeout = () -> completePendingRequest(generation, false);
+    mainHandler.postDelayed(pendingTimeout, SCO_CONNECT_TIMEOUT_MS);
+
+    if (!scoStarted) {
+      try {
+        // SCO is reference-counted per client. Acquire this instance's own
+        // reference even when another client established the link.
+        audioManager.startBluetoothSco();
+        scoStarted = true;
+      } catch (RuntimeException e) {
+        Log.w(TAG, "Unable to start Bluetooth SCO: " + e.getMessage());
+        completePendingRequest(generation, false);
+        return;
+      }
+    }
+
+    int stickyScoState = stickyState != null
+        ? stickyState.getIntExtra(
+            AudioManager.EXTRA_SCO_AUDIO_STATE, AudioManager.SCO_AUDIO_STATE_DISCONNECTED)
+        : AudioManager.SCO_AUDIO_STATE_DISCONNECTED;
+    if (alreadyConnected || stickyScoState == AudioManager.SCO_AUDIO_STATE_CONNECTED) {
+      audioManager.setBluetoothScoOn(true);
+      completePendingRequest(generation, true);
+    }
+  }
+
+  // MODE_NORMAL clears the mode set by this instance. Restoring a mode that
+  // was only observed could override another client's choice.
+  private void restoreSettledMode(Integer settledPluginMode) {
+    audioManager.setMode(
+        settledPluginMode != null ? settledPluginMode : AudioManager.MODE_NORMAL);
+    pluginSetMode = settledPluginMode;
+  }
+
+  private void rollbackPendingMode() {
+    if (!pendingModeApplied) {
+      return;
+    }
+    pendingModeApplied = false;
+    restoreSettledMode(pendingPreviousMode);
+    pendingPreviousMode = null;
+  }
+
+  private void settlePendingMode() {
+    pendingModeApplied = false;
+    pendingPreviousMode = null;
+  }
+
+  // Async callbacks are generation-guarded. Supersession and lifecycle
+  // cleanup use the unguarded overload and manage rollback directly.
+  private void completePendingRequest(int generation, boolean success) {
+    if (generation != requestGeneration) {
+      return;
+    }
+    if (!success) {
+      rollbackPendingMode();
+    }
+    completePendingRequest(success);
+  }
+
+  private void completePendingRequest(boolean success) {
+    requestGeneration++;
+    pendingModeApplied = false;
+    pendingPreviousMode = null;
+
+    boolean modernSelectionApplied = pendingSelectionActive;
+    AudioDeviceInfo previousCommunicationDevice = pendingPreviousCommunicationDevice;
+    boolean legacySpeakerphoneApplied = pendingLegacySpeakerphoneApplied;
+    boolean previousSpeakerphoneOn = pendingPreviousSpeakerphoneOn;
+    boolean previousAudioSettingsModified = pendingPreviousAudioSettingsModified;
+
+    Result result = pendingResult;
+    pendingResult = null;
+
+    if (pendingTimeout != null) {
+      mainHandler.removeCallbacks(pendingTimeout);
+      pendingTimeout = null;
+    }
+    if (pendingDeviceListener != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      audioManager.removeOnCommunicationDeviceChangedListener(
+          (AudioManager.OnCommunicationDeviceChangedListener) pendingDeviceListener);
+      pendingDeviceListener = null;
+    }
+    if (scoStateReceiver != null) {
+      if (!success) {
+        // Balance the SCO reference acquired for an aborted request.
+        stopScoIfStarted();
+      }
+      try {
+        context.unregisterReceiver(scoStateReceiver);
+      } catch (IllegalArgumentException e) {
+        Log.w(TAG, "SCO receiver already unregistered: " + e.getMessage());
+      }
+      scoStateReceiver = null;
+    }
+
+    if (modernSelectionApplied || legacySpeakerphoneApplied) {
+      if (success) {
+        modifiedAudioSettings = true;
+      } else {
+        if (modernSelectionApplied && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          restoreCommunicationDevice(
+              previousCommunicationDevice, previousAudioSettingsModified);
+        }
+        if (legacySpeakerphoneApplied) {
+          try {
+            audioManager.setSpeakerphoneOn(previousSpeakerphoneOn);
+          } catch (RuntimeException e) {
+            Log.w(TAG, "Unable to restore speakerphone route: " + e.getMessage());
+          }
+        }
+        modifiedAudioSettings = previousAudioSettingsModified;
+      }
+    }
+    pendingSelectionActive = false;
+    pendingPreviousCommunicationDevice = null;
+    pendingLegacySpeakerphoneApplied = false;
+    pendingPreviousSpeakerphoneOn = false;
+    pendingPreviousAudioSettingsModified = false;
+
+    if (result != null) {
+      result.success(success);
+      notifyInputChanged();
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.S)
+  private void restoreCommunicationDevice(
+      @Nullable AudioDeviceInfo previousDevice, boolean previousRouteOwnedByPlugin) {
+    try {
+      audioManager.clearCommunicationDevice();
+    } catch (RuntimeException e) {
+      Log.w(TAG, "Unable to clear failed communication route: " + e.getMessage());
+    }
+    if (!previousRouteOwnedByPlugin || previousDevice == null) {
+      // Clearing reveals the platform-selected route. Reselecting an unowned
+      // device would create a persistent request from this plugin.
+      return;
+    }
+    try {
+      if (!audioManager.setCommunicationDevice(previousDevice)) {
+        Log.w(TAG, "Unable to restore previous communication device");
+      }
+    } catch (RuntimeException e) {
+      Log.w(TAG, "Unable to restore communication device: " + e.getMessage());
+    }
+  }
+
+  // Queries
+
+  private List<String> getCurrentOutput() {
+    int port;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      AudioDeviceInfo device = audioManager.getCommunicationDevice();
+      port = device != null ? portForDeviceType(device.getType()) : PORT_UNKNOWN;
+      if (port == PORT_UNKNOWN) {
+        port = PORT_RECEIVER;
+      }
     } else {
-      // Fallback for older versions
-      return audioManager.isWiredHeadsetOn();
+      port = getCurrentOutputLegacy();
+    }
+    return Arrays.asList(nameForPort(port), String.valueOf(port));
+  }
+
+  @SuppressWarnings("deprecation")
+  private int getCurrentOutputLegacy() {
+    if (audioManager.isSpeakerphoneOn()) {
+      return PORT_SPEAKER;
+    } else if (audioManager.isBluetoothScoOn()) {
+      return PORT_BLUETOOTH;
+    } else if (isWiredHeadsetOn()) {
+      return PORT_HEADPHONES;
+    } else {
+      // Preserve the existing receiver fallback for API compatibility.
+      return PORT_RECEIVER;
     }
   }
 
   private List<List<String>> getAvailableInputs() {
     List<List<String>> list = new ArrayList<>();
-    list.add(Arrays.asList("Receiver", "1"));
-    list.add(Arrays.asList("Speaker", "2"));
-    
-    if (isWiredHeadsetOn()) {
-      list.add(Arrays.asList("Headset", "3"));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      Set<Integer> ports = new HashSet<>();
+      for (AudioDeviceInfo device : audioManager.getAvailableCommunicationDevices()) {
+        int port = portForDeviceType(device.getType());
+        if (port != PORT_UNKNOWN) {
+          ports.add(port);
+        }
+      }
+      // Preserve the legacy discovery contract, which includes physical
+      // outputs that may not be selectable communication routes.
+      for (AudioDeviceInfo device : audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
+        switch (device.getType()) {
+          case AudioDeviceInfo.TYPE_BUILTIN_EARPIECE:
+            ports.add(PORT_RECEIVER);
+            break;
+          case AudioDeviceInfo.TYPE_BLUETOOTH_A2DP:
+            ports.add(PORT_BLUETOOTH);
+            break;
+          case AudioDeviceInfo.TYPE_WIRED_HEADPHONES:
+            ports.add(PORT_HEADPHONES);
+            break;
+          default:
+            break;
+        }
+      }
+      for (int port : new int[] {PORT_RECEIVER, PORT_SPEAKER, PORT_HEADPHONES, PORT_BLUETOOTH}) {
+        if (ports.contains(port)) {
+          list.add(Arrays.asList(nameForPort(port), String.valueOf(port)));
+        }
+      }
+    } else {
+      list.add(Arrays.asList(nameForPort(PORT_RECEIVER), String.valueOf(PORT_RECEIVER)));
+      list.add(Arrays.asList(nameForPort(PORT_SPEAKER), String.valueOf(PORT_SPEAKER)));
+      if (isWiredHeadsetOn()) {
+        list.add(Arrays.asList(nameForPort(PORT_HEADPHONES), String.valueOf(PORT_HEADPHONES)));
+      }
+      if (isBluetoothAvailable()) {
+        list.add(Arrays.asList(nameForPort(PORT_BLUETOOTH), String.valueOf(PORT_BLUETOOTH)));
+      }
     }
-    
-    if (isBluetoothAvailable()) {
-      list.add(Arrays.asList("Bluetooth", "4"));
-    }
-    
     return list;
+  }
+
+  private static String nameForPort(int port) {
+    switch (port) {
+      case PORT_RECEIVER:
+        return "Receiver";
+      case PORT_SPEAKER:
+        return "Speaker";
+      case PORT_HEADPHONES:
+        return "Headset";
+      case PORT_BLUETOOTH:
+        return "Bluetooth";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private static int portForDeviceType(int type) {
+    switch (type) {
+      case AudioDeviceInfo.TYPE_BUILTIN_EARPIECE:
+        return PORT_RECEIVER;
+      case AudioDeviceInfo.TYPE_BUILTIN_SPEAKER:
+        return PORT_SPEAKER;
+      case AudioDeviceInfo.TYPE_WIRED_HEADSET:
+      case AudioDeviceInfo.TYPE_WIRED_HEADPHONES:
+      case AudioDeviceInfo.TYPE_USB_HEADSET:
+      case AudioDeviceInfo.TYPE_USB_DEVICE:
+      case AudioDeviceInfo.TYPE_USB_ACCESSORY:
+        return PORT_HEADPHONES;
+      case AudioDeviceInfo.TYPE_BLUETOOTH_SCO:
+      case AudioDeviceInfo.TYPE_BLUETOOTH_A2DP:
+      case AudioDeviceInfo.TYPE_BLE_HEADSET:
+      case AudioDeviceInfo.TYPE_BLE_SPEAKER:
+      case AudioDeviceInfo.TYPE_BLE_BROADCAST:
+      case AudioDeviceInfo.TYPE_HEARING_AID:
+        return PORT_BLUETOOTH;
+      default:
+        return PORT_UNKNOWN;
+    }
+  }
+
+  private boolean isWiredHeadsetOn() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return hasOutputDeviceType(
+          AudioDeviceInfo.TYPE_WIRED_HEADPHONES, AudioDeviceInfo.TYPE_WIRED_HEADSET);
+    } else {
+      return legacyIsWiredHeadsetOn();
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  private boolean hasOutputDeviceType(int... types) {
+    for (AudioDeviceInfo deviceInfo : audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
+      for (int type : types) {
+        if (deviceInfo.getType() == type) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  @SuppressWarnings("deprecation")
+  private boolean legacyIsWiredHeadsetOn() {
+    return audioManager.isWiredHeadsetOn();
+  }
+
+  @SuppressWarnings("deprecation")
+  private void stopScoIfStarted() {
+    if (scoStarted) {
+      audioManager.stopBluetoothSco();
+      scoStarted = false;
+    }
   }
 
   private boolean isBluetoothAvailable() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      AudioDeviceInfo[] audioDevices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
-      for (AudioDeviceInfo deviceInfo : audioDevices) {
-        if (deviceInfo.getType() == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
-            deviceInfo.getType() == AudioDeviceInfo.TYPE_BLUETOOTH_SCO) {
-          return true;
-        }
-      }
-      return false;
+      return hasOutputDeviceType(
+          AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
     } else {
-      // For older versions, we'll assume bluetooth is available if SCO is on
-      return audioManager.isBluetoothScoOn();
+      return legacyIsBluetoothScoOn();
+    }
+  }
+
+  private boolean isBluetoothCommunicationAvailable() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      // Legacy switching uses SCO. An A2DP-only device is discoverable but is
+      // not a valid communication route.
+      return hasOutputDeviceType(AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+    } else {
+      return legacyIsBluetoothScoOn();
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private boolean legacyIsBluetoothScoOn() {
+    return audioManager.isBluetoothScoOn();
+  }
+
+  // Lifecycle and events
+
+  private void notifyInputChanged() {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      if (channel != null) {
+        channel.invokeMethod("inputChanged", 1);
+      }
+    } else {
+      mainHandler.post(() -> {
+        if (channel != null) {
+          channel.invokeMethod("inputChanged", 1);
+        }
+      });
     }
   }
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    // Unregister receiver
+    completePendingRequest(false);
+
+    if (audioDeviceCallback != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      audioManager.unregisterAudioDeviceCallback(audioDeviceCallback);
+      audioDeviceCallback = null;
+    }
     if (audioChangeReceiver != null && context != null) {
       try {
         context.unregisterReceiver(audioChangeReceiver);
       } catch (IllegalArgumentException e) {
         Log.w(TAG, "Receiver not registered: " + e.getMessage());
       }
+      audioChangeReceiver = null;
     }
-    
-    // Clean up channel
+
     if (channel != null) {
       channel.setMethodCallHandler(null);
       channel = null;
     }
-    
-    // Reset audio manager to normal mode
+
+    // Avoid process-wide resets when this instance recorded no change.
     if (audioManager != null) {
-      audioManager.setMode(AudioManager.MODE_NORMAL);
+      if (modifiedAudioSettings) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          audioManager.clearCommunicationDevice();
+        } else {
+          resetLegacyRouting();
+        }
+      }
+      if (pluginSetMode != null) {
+        audioManager.setMode(AudioManager.MODE_NORMAL);
+        pluginSetMode = null;
+      }
     }
-    
+    modifiedAudioSettings = false;
+
     context = null;
     audioManager = null;
-    audioChangeReceiver = null;
   }
 }

--- a/android/src/test/java/com/itsmurphy/flutter_audio_output/FlutterAudioOutputPluginApi21Test.java
+++ b/android/src/test/java/com/itsmurphy/flutter_audio_output/FlutterAudioOutputPluginApi21Test.java
@@ -1,0 +1,44 @@
+package com.itsmurphy.flutter_audio_output;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.media.AudioManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+/** Exercises the API 21 fallback, where output enumeration is unavailable. */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 21)
+public class FlutterAudioOutputPluginApi21Test {
+
+  @Test
+  public void bluetoothSwitchDoesNotFailFastWithoutAvailabilityCheck() {
+    AudioManager audioManager = mock(AudioManager.class);
+    Context context = mock(Context.class);
+    when(context.getSystemService(Context.AUDIO_SERVICE)).thenReturn(audioManager);
+    FlutterPlugin.FlutterPluginBinding binding = mock(FlutterPlugin.FlutterPluginBinding.class);
+    when(binding.getApplicationContext()).thenReturn(context);
+    when(binding.getBinaryMessenger()).thenReturn(mock(BinaryMessenger.class));
+    MethodChannel.Result result = mock(MethodChannel.Result.class);
+
+    FlutterAudioOutputPlugin plugin = new FlutterAudioOutputPlugin();
+    plugin.onAttachedToEngine(binding);
+    plugin.onMethodCall(new MethodCall("changeToBluetooth", null), result);
+
+    verify(audioManager).startBluetoothSco();
+    verify(result, never()).success(any());
+  }
+}

--- a/android/src/test/java/com/itsmurphy/flutter_audio_output/FlutterAudioOutputPluginLegacyTest.java
+++ b/android/src/test/java/com/itsmurphy/flutter_audio_output/FlutterAudioOutputPluginLegacyTest.java
@@ -1,0 +1,313 @@
+package com.itsmurphy.flutter_audio_output;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+import android.os.Looper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.time.Duration;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+/** Legacy speakerphone and Bluetooth SCO routing. */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class FlutterAudioOutputPluginLegacyTest {
+
+  private AudioManager audioManager;
+  private Context context;
+  private FlutterPlugin.FlutterPluginBinding binding;
+  private FlutterAudioOutputPlugin plugin;
+  private MethodChannel.Result result;
+
+  @Before
+  public void setUp() {
+    audioManager = mock(AudioManager.class);
+    context = mock(Context.class);
+    when(context.getSystemService(Context.AUDIO_SERVICE)).thenReturn(audioManager);
+    binding = mock(FlutterPlugin.FlutterPluginBinding.class);
+    when(binding.getApplicationContext()).thenReturn(context);
+    when(binding.getBinaryMessenger()).thenReturn(mock(BinaryMessenger.class));
+    result = mock(MethodChannel.Result.class);
+
+    when(audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS))
+        .thenReturn(new AudioDeviceInfo[0]);
+
+    plugin = new FlutterAudioOutputPlugin();
+    plugin.onAttachedToEngine(binding);
+  }
+
+  private void call(String method, MethodChannel.Result result) {
+    plugin.onMethodCall(new MethodCall(method, null), result);
+  }
+
+  private void stubScoDeviceAvailable() {
+    AudioDeviceInfo sco = mock(AudioDeviceInfo.class);
+    when(sco.getType()).thenReturn(AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
+    when(audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS))
+        .thenReturn(new AudioDeviceInfo[] {sco});
+  }
+
+  private void stubA2dpDeviceAvailable() {
+    AudioDeviceInfo a2dp = mock(AudioDeviceInfo.class);
+    when(a2dp.getType()).thenReturn(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP);
+    when(audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS))
+        .thenReturn(new AudioDeviceInfo[] {a2dp});
+  }
+
+  private BroadcastReceiver capturedScoReceiver() {
+    ArgumentCaptor<BroadcastReceiver> captor = ArgumentCaptor.forClass(BroadcastReceiver.class);
+    verify(context).registerReceiver(captor.capture(), any(IntentFilter.class));
+    return captor.getValue();
+  }
+
+  private static Intent scoIntent(int state) {
+    Intent intent = new Intent(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED);
+    intent.putExtra(AudioManager.EXTRA_SCO_AUDIO_STATE, state);
+    return intent;
+  }
+
+  @Test
+  public void bluetoothSwitchCompletesOnScoConnected() {
+    stubScoDeviceAvailable();
+
+    call("changeToBluetooth", result);
+
+    verify(audioManager).startBluetoothSco();
+    verify(result, never()).success(any());
+
+    BroadcastReceiver receiver = capturedScoReceiver();
+    receiver.onReceive(context, scoIntent(AudioManager.SCO_AUDIO_STATE_CONNECTED));
+
+    verify(audioManager).setBluetoothScoOn(true);
+    verify(result).success(true);
+  }
+
+  @Test
+  public void scoDisconnectAfterConnectingFailsAndBalancesRefcount() {
+    stubScoDeviceAvailable();
+    call("changeToBluetooth", result);
+    BroadcastReceiver receiver = capturedScoReceiver();
+
+    receiver.onReceive(context, scoIntent(AudioManager.SCO_AUDIO_STATE_CONNECTING));
+    verify(result, never()).success(any());
+
+    receiver.onReceive(context, scoIntent(AudioManager.SCO_AUDIO_STATE_DISCONNECTED));
+
+    verify(result).success(false);
+    verify(audioManager).stopBluetoothSco();
+  }
+
+  @Test
+  public void scoConnectTimeoutFails() {
+    stubScoDeviceAvailable();
+    call("changeToBluetooth", result);
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(10000));
+
+    verify(result).success(false);
+    verify(audioManager).stopBluetoothSco();
+    verify(context).unregisterReceiver(any(BroadcastReceiver.class));
+  }
+
+  @Test
+  public void scoTimeoutRestoresPreviousSpeakerphoneRoute() {
+    stubScoDeviceAvailable();
+    when(audioManager.isSpeakerphoneOn()).thenReturn(true);
+
+    call("changeToBluetooth", result);
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(10000));
+
+    verify(result).success(false);
+    verify(audioManager).setSpeakerphoneOn(false);
+    verify(audioManager).setSpeakerphoneOn(true);
+  }
+
+  @Test
+  public void startBluetoothScoExceptionRestoresAudioState() {
+    stubScoDeviceAvailable();
+    when(audioManager.isSpeakerphoneOn()).thenReturn(true);
+    doThrow(new IllegalStateException("SCO unavailable"))
+        .when(audioManager).startBluetoothSco();
+
+    call("changeToBluetooth", result);
+
+    verify(result).success(false);
+    verify(audioManager).setSpeakerphoneOn(false);
+    verify(audioManager).setSpeakerphoneOn(true);
+    verify(audioManager).setMode(AudioManager.MODE_IN_COMMUNICATION);
+    verify(audioManager).setMode(AudioManager.MODE_NORMAL);
+    verify(context).unregisterReceiver(any(BroadcastReceiver.class));
+    verify(audioManager, never()).stopBluetoothSco();
+  }
+
+  @Test
+  public void speakerSwitchSucceedsImmediately() {
+    call("changeToSpeaker", result);
+
+    verify(audioManager).setSpeakerphoneOn(true);
+    verify(result).success(true);
+  }
+
+  @Test
+  public void headphonesWithoutWiredDeviceFailsWithoutTouchingAudioState() {
+    call("changeToHeadphones", result);
+
+    verify(result).success(false);
+    verify(audioManager, never()).setSpeakerphoneOn(anyBoolean());
+    verify(audioManager, never()).setMode(anyInt());
+  }
+
+  @Test
+  public void bluetoothUnavailableFailsBeforeTouchingAudioState() {
+    call("changeToBluetooth", result);
+
+    verify(result).success(false);
+    verify(audioManager, never()).setMode(anyInt());
+    verify(audioManager, never()).setSpeakerphoneOn(anyBoolean());
+    verify(audioManager, never()).startBluetoothSco();
+  }
+
+  @Test
+  public void a2dpOnlyDeviceCannotSatisfyScoRoute() {
+    stubA2dpDeviceAvailable();
+
+    call("changeToBluetooth", result);
+
+    verify(result).success(false);
+    verify(audioManager, never()).setMode(anyInt());
+    verify(audioManager, never()).startBluetoothSco();
+  }
+
+  @Test
+  public void externallyConnectedScoStillAcquiresPluginRequest() {
+    stubScoDeviceAvailable();
+    when(audioManager.isBluetoothScoOn()).thenReturn(true);
+    when(context.registerReceiver(
+            any(BroadcastReceiver.class), any(IntentFilter.class)))
+        .thenReturn(scoIntent(AudioManager.SCO_AUDIO_STATE_CONNECTED));
+
+    call("changeToBluetooth", result);
+
+    verify(audioManager).startBluetoothSco();
+    verify(audioManager).setBluetoothScoOn(true);
+    verify(result).success(true);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", releaseResult);
+    verify(audioManager, times(1)).stopBluetoothSco();
+  }
+
+  @Test
+  public void connectedStickyStateCompletesAfterAcquiringScoRequest() {
+    stubScoDeviceAvailable();
+    when(context.registerReceiver(
+            any(BroadcastReceiver.class), any(IntentFilter.class)))
+        .thenReturn(scoIntent(AudioManager.SCO_AUDIO_STATE_CONNECTED));
+
+    call("changeToBluetooth", result);
+
+    verify(audioManager).startBluetoothSco();
+    verify(audioManager).setBluetoothScoOn(true);
+    verify(result).success(true);
+  }
+
+  @Test
+  public void scoTimeoutRollsBackAppliedMode() {
+    stubScoDeviceAvailable();
+    call("changeToBluetooth", result);
+    verify(audioManager).setMode(AudioManager.MODE_IN_COMMUNICATION);
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(10000));
+
+    verify(result).success(false);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", releaseResult);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+  }
+
+  @Test
+  public void staleScoBroadcastDoesNotAffectSuccessor() {
+    stubScoDeviceAvailable();
+    call("changeToBluetooth", result);
+    BroadcastReceiver receiver = capturedScoReceiver();
+
+    MethodChannel.Result speakerResult = mock(MethodChannel.Result.class);
+    call("changeToSpeaker", speakerResult);
+    verify(result, times(1)).success(false);
+    verify(speakerResult, times(1)).success(true);
+
+    // Simulate a broadcast queued before receiver removal.
+    receiver.onReceive(context, scoIntent(AudioManager.SCO_AUDIO_STATE_CONNECTED));
+
+    verify(audioManager, never()).setBluetoothScoOn(true);
+    verify(result, times(1)).success(false);
+    verify(speakerResult, times(1)).success(true);
+  }
+
+  @Test
+  public void detachAfterSwitchResetsLegacyRoutingWithoutUnbalancedScoStop() {
+    call("changeToSpeaker", result);
+    clearInvocations(audioManager);
+
+    plugin.onDetachedFromEngine(binding);
+
+    verify(audioManager, never()).stopBluetoothSco();
+    verify(audioManager).setBluetoothScoOn(false);
+    verify(audioManager).setSpeakerphoneOn(false);
+    verify(audioManager).setMode(AudioManager.MODE_NORMAL);
+  }
+
+  @Test
+  public void releaseDuringPendingScoStopsExactlyOnce() {
+    stubScoDeviceAvailable();
+    call("changeToBluetooth", result);
+    verify(audioManager, times(1)).startBluetoothSco();
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", releaseResult);
+
+    verify(result, times(1)).success(false);
+    verify(releaseResult).success(null);
+    verify(audioManager, times(1)).stopBluetoothSco();
+  }
+
+  @Test
+  public void detachDuringPendingScoStopsExactlyOnce() {
+    stubScoDeviceAvailable();
+    call("changeToBluetooth", result);
+    verify(audioManager, times(1)).startBluetoothSco();
+
+    plugin.onDetachedFromEngine(binding);
+
+    verify(result, times(1)).success(false);
+    verify(audioManager, times(1)).stopBluetoothSco();
+  }
+}

--- a/android/src/test/java/com/itsmurphy/flutter_audio_output/FlutterAudioOutputPluginModernTest.java
+++ b/android/src/test/java/com/itsmurphy/flutter_audio_output/FlutterAudioOutputPluginModernTest.java
@@ -1,0 +1,581 @@
+package com.itsmurphy.flutter_audio_output;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.Context;
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+import android.os.Looper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+/** Communication-device routing on API 31 and later. */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class FlutterAudioOutputPluginModernTest {
+
+  private AudioManager audioManager;
+  private Context context;
+  private FlutterPlugin.FlutterPluginBinding binding;
+  private FlutterAudioOutputPlugin plugin;
+  private MethodChannel.Result result;
+
+  private AudioDeviceInfo earpiece;
+  private AudioDeviceInfo speaker;
+  private AudioDeviceInfo bluetooth;
+
+  @Before
+  public void setUp() {
+    audioManager = mock(AudioManager.class);
+    context = mock(Context.class);
+    when(context.getSystemService(Context.AUDIO_SERVICE)).thenReturn(audioManager);
+    binding = mock(FlutterPlugin.FlutterPluginBinding.class);
+    when(binding.getApplicationContext()).thenReturn(context);
+    when(binding.getBinaryMessenger()).thenReturn(mock(BinaryMessenger.class));
+    result = mock(MethodChannel.Result.class);
+
+    earpiece = device(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE, 1);
+    speaker = device(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, 2);
+    bluetooth = device(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, 5);
+    when(audioManager.getAvailableCommunicationDevices())
+        .thenReturn(Arrays.asList(earpiece, speaker, bluetooth));
+    when(audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS))
+        .thenReturn(new AudioDeviceInfo[0]);
+    when(audioManager.setCommunicationDevice(any())).thenReturn(true);
+
+    plugin = new FlutterAudioOutputPlugin();
+    plugin.onAttachedToEngine(binding);
+  }
+
+  private static AudioDeviceInfo device(int type, int id) {
+    AudioDeviceInfo info = mock(AudioDeviceInfo.class);
+    when(info.getType()).thenReturn(type);
+    when(info.getId()).thenReturn(id);
+    return info;
+  }
+
+  private void call(String method, Map<String, Object> args, MethodChannel.Result result) {
+    plugin.onMethodCall(new MethodCall(method, args), result);
+  }
+
+  private List<AudioManager.OnCommunicationDeviceChangedListener> capturedListeners(int count) {
+    ArgumentCaptor<AudioManager.OnCommunicationDeviceChangedListener> captor =
+        ArgumentCaptor.forClass(AudioManager.OnCommunicationDeviceChangedListener.class);
+    verify(audioManager, times(count))
+        .addOnCommunicationDeviceChangedListener(any(), captor.capture());
+    return captor.getAllValues();
+  }
+
+  @Test
+  public void speakerSwitchCompletesOnceOnListener() {
+    call("changeToSpeaker", null, result);
+
+    verify(audioManager).setCommunicationDevice(speaker);
+    verify(audioManager).setMode(AudioManager.MODE_NORMAL);
+    verify(result, never()).success(any());
+
+    AudioManager.OnCommunicationDeviceChangedListener listener = capturedListeners(1).get(0);
+    listener.onCommunicationDeviceChanged(speaker);
+    listener.onCommunicationDeviceChanged(speaker);
+
+    verify(result, times(1)).success(true);
+  }
+
+  @Test
+  public void speakerSwitchAlreadyActiveSucceedsWithoutListener() {
+    when(audioManager.getCommunicationDevice()).thenReturn(speaker);
+
+    call("changeToSpeaker", null, result);
+
+    verify(result).success(true);
+    verify(audioManager, never()).setCommunicationDevice(any());
+    verify(audioManager, never()).addOnCommunicationDeviceChangedListener(any(), any());
+  }
+
+  @Test
+  public void speakerSwitchTimeoutClearsUnconfirmedSelectionAndFails() {
+    call("changeToSpeaker", null, result);
+    verify(result, never()).success(any());
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(5000));
+
+    verify(audioManager).clearCommunicationDevice();
+    verify(result).success(false);
+  }
+
+  @Test
+  public void newRequestSupersedesPendingOne() {
+    MethodChannel.Result first = mock(MethodChannel.Result.class);
+    call("changeToBluetooth", null, first);
+    verify(audioManager).setCommunicationDevice(bluetooth);
+
+    call("changeToSpeaker", null, result);
+
+    verify(first, times(1)).success(false);
+    verify(first, never()).success(true);
+    verify(audioManager).clearCommunicationDevice();
+    List<AudioManager.OnCommunicationDeviceChangedListener> listeners = capturedListeners(2);
+    verify(audioManager).removeOnCommunicationDeviceChangedListener(listeners.get(0));
+    verify(audioManager).setCommunicationDevice(speaker);
+    verify(result, never()).success(any());
+  }
+
+  @Test
+  public void staleListenerDoesNotCompleteSupersedingRequest() {
+    MethodChannel.Result first = mock(MethodChannel.Result.class);
+    call("changeToBluetooth", null, first);
+    call("changeToSpeaker", null, result);
+
+    List<AudioManager.OnCommunicationDeviceChangedListener> listeners = capturedListeners(2);
+    listeners.get(0).onCommunicationDeviceChanged(bluetooth);
+    verify(result, never()).success(any());
+
+    listeners.get(1).onCommunicationDeviceChanged(speaker);
+    verify(result).success(true);
+  }
+
+  @Test
+  public void failedSuccessorRestoresSettledRouteNotSupersededTarget() {
+    MethodChannel.Result initial = mock(MethodChannel.Result.class);
+    call("changeToSpeaker", null, initial);
+    capturedListeners(1).get(0).onCommunicationDeviceChanged(speaker);
+
+    when(audioManager.getCommunicationDevice()).thenReturn(speaker);
+    MethodChannel.Result superseded = mock(MethodChannel.Result.class);
+    call("changeToBluetooth", null, superseded);
+
+    // The canceled target can remain current while restoring the settled
+    // speaker route. The successor must inherit the saved speaker baseline
+    // instead of adopting this transient Bluetooth device.
+    when(audioManager.getCommunicationDevice()).thenReturn(bluetooth);
+    MethodChannel.Result successor = mock(MethodChannel.Result.class);
+    call("changeToReceiver", null, successor);
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(5000));
+
+    verify(superseded).success(false);
+    verify(successor).success(false);
+    verify(audioManager, times(1)).setCommunicationDevice(bluetooth);
+    verify(audioManager).setCommunicationDevice(earpiece);
+    verify(audioManager, times(3)).setCommunicationDevice(speaker);
+  }
+
+  @Test
+  public void receiverWithoutEarpieceFailsWithoutChangingRoute() {
+    when(audioManager.getAvailableCommunicationDevices())
+        .thenReturn(Collections.singletonList(speaker));
+
+    call("changeToReceiver", null, result);
+
+    verify(result).success(false);
+    verify(audioManager, never()).clearCommunicationDevice();
+    verify(audioManager, never()).setCommunicationDevice(any());
+    verify(audioManager, never()).setMode(anyInt());
+  }
+
+  @Test
+  public void headphonesWithoutWiredDeviceFails() {
+    call("changeToHeadphones", null, result);
+
+    verify(result).success(false);
+    verify(audioManager, never()).setCommunicationDevice(any());
+  }
+
+  @Test
+  public void bluetoothUnavailableFailsWithoutTouchingMode() {
+    when(audioManager.getAvailableCommunicationDevices())
+        .thenReturn(Arrays.asList(earpiece, speaker));
+
+    call("changeToBluetooth", null, result);
+
+    verify(result).success(false);
+    verify(audioManager, never()).setMode(anyInt());
+    verify(audioManager, never()).setCommunicationDevice(any());
+    verify(audioManager, never()).addOnCommunicationDeviceChangedListener(any(), any());
+  }
+
+  @Test
+  public void routeTimeoutRollsBackAppliedMode() {
+    call("changeToSpeaker", null, result);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(5000));
+
+    verify(result).success(false);
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+  }
+
+  @Test
+  public void firstFailureReleasesModeInsteadOfAdoptingAnotherAppsMode() {
+    when(audioManager.getMode()).thenReturn(AudioManager.MODE_IN_COMMUNICATION);
+
+    call("changeToSpeaker", null, result);
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(5000));
+
+    verify(result).success(false);
+    // Reapplying the observed mode would make this instance its owner.
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+    verify(audioManager, never()).setMode(AudioManager.MODE_IN_COMMUNICATION);
+  }
+
+  @Test
+  public void rollbackRestoresPreviousPluginOwnedMode() {
+    when(audioManager.getCommunicationDevice()).thenReturn(speaker);
+    call("changeToSpeaker", null, result);
+    verify(result).success(true);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+
+    MethodChannel.Result bluetoothResult = mock(MethodChannel.Result.class);
+    call("changeToBluetooth", null, bluetoothResult);
+    verify(audioManager).setMode(AudioManager.MODE_IN_COMMUNICATION);
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(30000));
+
+    verify(bluetoothResult).success(false);
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+    verify(audioManager, times(3)).setMode(AudioManager.MODE_NORMAL);
+  }
+
+  @Test
+  public void syncSetCommunicationDeviceFailureRollsBackAppliedMode() {
+    when(audioManager.setCommunicationDevice(speaker)).thenReturn(false);
+
+    call("changeToSpeaker", null, result);
+
+    verify(result, times(1)).success(false);
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+    verify(audioManager).removeOnCommunicationDeviceChangedListener(any());
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(5000));
+    verify(result, times(1)).success(false);
+  }
+
+  @Test
+  public void setCommunicationDeviceExceptionCompletesFalseAndCleansUp() {
+    doThrow(new IllegalArgumentException("device disconnected"))
+        .when(audioManager).setCommunicationDevice(speaker);
+
+    call("changeToSpeaker", null, result);
+
+    verify(result).success(false);
+    verify(audioManager).clearCommunicationDevice();
+    verify(audioManager).removeOnCommunicationDeviceChangedListener(any());
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(5000));
+    verify(result, times(1)).success(false);
+  }
+
+  @Test
+  public void deviceLostAfterPreflightRollsBackAppliedMode() {
+    when(audioManager.getAvailableCommunicationDevices())
+        .thenReturn(Arrays.asList(earpiece, speaker, bluetooth))
+        .thenReturn(Arrays.asList(earpiece, speaker));
+
+    call("changeToBluetooth", null, result);
+
+    verify(result).success(false);
+    verify(audioManager).setMode(AudioManager.MODE_IN_COMMUNICATION);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+    verify(audioManager, never()).setCommunicationDevice(any());
+  }
+
+  @Test
+  public void preflightFailingSuccessorRollsBackInheritedMode() {
+    MethodChannel.Result first = mock(MethodChannel.Result.class);
+    call("changeToBluetooth", null, first);
+    verify(audioManager).setMode(AudioManager.MODE_IN_COMMUNICATION);
+
+    // The unavailable successor must restore the inherited mode baseline.
+    call("changeToHeadphones", null, result);
+
+    verify(first, times(1)).success(false);
+    verify(result, times(1)).success(false);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+  }
+
+  @Test
+  public void speakerSuccessorAppliesNormalModeImmediately() {
+    MethodChannel.Result first = mock(MethodChannel.Result.class);
+    call("changeToBluetooth", null, first);
+    verify(audioManager).setMode(AudioManager.MODE_IN_COMMUNICATION);
+
+    call("changeToSpeaker", null, result);
+
+    verify(first, times(1)).success(false);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+    verify(result, never()).success(any());
+  }
+
+  @Test
+  public void successorRollbackRestoresSettledModeNotTransient() {
+    MethodChannel.Result first = mock(MethodChannel.Result.class);
+    call("changeToReceiver", null, first);
+    verify(audioManager).setMode(AudioManager.MODE_IN_COMMUNICATION);
+
+    call("changeToSpeaker", null, result);
+    verify(first, times(1)).success(false);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(5000));
+
+    // Restore the settled baseline, not the superseded request's transient mode.
+    verify(result).success(false);
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_IN_COMMUNICATION);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+  }
+
+  @Test
+  public void supersededRequestDoesNotRollBackSuccessorMode() {
+    MethodChannel.Result first = mock(MethodChannel.Result.class);
+    call("changeToSpeaker", null, first);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+
+    call("changeToReceiver", null, result);
+
+    // Supersession must not reapply the first request's mode.
+    verify(first, times(1)).success(false);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_NORMAL);
+    verify(audioManager, times(1)).setMode(AudioManager.MODE_IN_COMMUNICATION);
+  }
+
+  @Test
+  public void speakerPreservesNormalMode() {
+    when(audioManager.getCommunicationDevice()).thenReturn(speaker);
+
+    call("changeToSpeaker", null, result);
+
+    verify(audioManager).setMode(AudioManager.MODE_NORMAL);
+  }
+
+  @Test
+  public void receiverPreservesInCommunicationMode() {
+    when(audioManager.getCommunicationDevice()).thenReturn(earpiece);
+
+    call("changeToReceiver", null, result);
+
+    verify(audioManager).setMode(AudioManager.MODE_IN_COMMUNICATION);
+  }
+
+  @Test
+  public void releaseAfterConfirmedSwitchClearsDeviceAndRestoresMode() {
+    call("changeToSpeaker", null, result);
+    capturedListeners(1).get(0).onCommunicationDeviceChanged(speaker);
+    verify(result).success(true);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+
+    verify(audioManager).clearCommunicationDevice();
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+    verify(releaseResult).success(null);
+  }
+
+  @Test
+  public void failedSwitchRestoresPreviousCommunicationDevice() {
+    MethodChannel.Result first = mock(MethodChannel.Result.class);
+    call("changeToSpeaker", null, first);
+    capturedListeners(1).get(0).onCommunicationDeviceChanged(speaker);
+
+    when(audioManager.getCommunicationDevice()).thenReturn(speaker);
+    MethodChannel.Result second = mock(MethodChannel.Result.class);
+    call("changeToBluetooth", null, second);
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(30000));
+
+    verify(second).success(false);
+    verify(audioManager).setCommunicationDevice(bluetooth);
+    verify(audioManager).clearCommunicationDevice();
+    verify(audioManager, times(2)).setCommunicationDevice(speaker);
+  }
+
+  @Test
+  public void firstFailedSwitchDoesNotAdoptSystemCommunicationDevice() {
+    when(audioManager.getCommunicationDevice()).thenReturn(speaker);
+
+    call("changeToBluetooth", null, result);
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(30000));
+
+    verify(result).success(false);
+    verify(audioManager).setCommunicationDevice(bluetooth);
+    verify(audioManager).clearCommunicationDevice();
+    verify(audioManager, never()).setCommunicationDevice(speaker);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+
+    verify(audioManager, times(1)).clearCommunicationDevice();
+    verify(releaseResult).success(null);
+  }
+
+  @Test
+  public void releaseWithoutOwnedRouteClearsNothing() {
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+
+    verify(audioManager, never()).clearCommunicationDevice();
+    verify(audioManager, never()).setMode(anyInt());
+    verify(releaseResult).success(null);
+  }
+
+  @Test
+  public void releaseAfterInCommunicationSwitchRestoresNormalMode() {
+    when(audioManager.getCommunicationDevice()).thenReturn(earpiece);
+    call("changeToReceiver", null, result);
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+
+    verify(audioManager).setMode(AudioManager.MODE_NORMAL);
+    verify(releaseResult).success(null);
+  }
+
+  @Test
+  public void releaseAbortsPendingRequest() {
+    call("changeToSpeaker", null, result);
+    verify(result, never()).success(any());
+
+    MethodChannel.Result releaseResult = mock(MethodChannel.Result.class);
+    call("release", null, releaseResult);
+
+    verify(result, times(1)).success(false);
+    verify(releaseResult).success(null);
+  }
+
+  @Test
+  public void detachWithoutModificationsLeavesAudioStateAlone() {
+    plugin.onDetachedFromEngine(binding);
+
+    verify(audioManager, never()).clearCommunicationDevice();
+    verify(audioManager, never()).setMode(anyInt());
+  }
+
+  @Test
+  public void detachAfterConfirmedSwitchClearsDeviceAndRestoresMode() {
+    call("changeToSpeaker", null, result);
+    capturedListeners(1).get(0).onCommunicationDeviceChanged(speaker);
+    verify(result).success(true);
+
+    plugin.onDetachedFromEngine(binding);
+
+    verify(audioManager).clearCommunicationDevice();
+    verify(audioManager, times(2)).setMode(AudioManager.MODE_NORMAL);
+  }
+
+  @Test
+  public void detachAfterEarlyExitSwitchDoesNotClaimTheRoute() {
+    when(audioManager.getCommunicationDevice()).thenReturn(speaker);
+    call("changeToSpeaker", null, result);
+    verify(result).success(true);
+
+    plugin.onDetachedFromEngine(binding);
+
+    verify(audioManager, never()).clearCommunicationDevice();
+  }
+
+  @Test
+  public void detachAfterFailedRequestDoesNotClaimTheRoute() {
+    when(audioManager.getAvailableCommunicationDevices())
+        .thenReturn(Arrays.asList(earpiece, speaker));
+    call("changeToHeadphones", null, result);
+    verify(result).success(false);
+
+    plugin.onDetachedFromEngine(binding);
+
+    verify(audioManager, never()).clearCommunicationDevice();
+  }
+
+  @Test
+  public void pendingBluetoothSupersededByUnavailableRequestFailsBothAndClears() {
+    MethodChannel.Result first = mock(MethodChannel.Result.class);
+    call("changeToBluetooth", null, first);
+    verify(audioManager).setCommunicationDevice(bluetooth);
+
+    when(audioManager.getAvailableCommunicationDevices())
+        .thenReturn(Arrays.asList(earpiece, speaker));
+    call("changeToHeadphones", null, result);
+
+    verify(first, times(1)).success(false);
+    verify(result, times(1)).success(false);
+    verify(audioManager).clearCommunicationDevice();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void getAvailableInputsPreservesA2dpDiscovery() {
+    AudioDeviceInfo a2dp = device(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, 9);
+    when(audioManager.getAvailableCommunicationDevices())
+        .thenReturn(Arrays.asList(earpiece, speaker));
+    when(audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS))
+        .thenReturn(new AudioDeviceInfo[] {a2dp});
+
+    call("getAvailableInputs", null, result);
+
+    ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+    verify(result).success(captor.capture());
+    List<List<String>> inputs = (List<List<String>>) captor.getValue();
+    assertEquals(
+        Arrays.asList(
+            Arrays.asList("Receiver", "1"),
+            Arrays.asList("Speaker", "2"),
+            Arrays.asList("Bluetooth", "4")),
+        inputs);
+  }
+
+  @Test
+  public void getCurrentOutputMapsCommunicationDeviceType() {
+    when(audioManager.getCommunicationDevice()).thenReturn(speaker);
+
+    call("getCurrentOutput", null, result);
+
+    verify(result).success(Arrays.asList("Speaker", "2"));
+  }
+
+  @Test
+  public void getCurrentOutputPreservesReceiverFallbackWithoutCommunicationDevice() {
+    when(audioManager.getCommunicationDevice()).thenReturn(null);
+
+    call("getCurrentOutput", null, result);
+
+    verify(result).success(Arrays.asList("Receiver", "1"));
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.1.0"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -202,26 +202,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -375,10 +375,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -436,5 +436,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/ios/Classes/SwiftFlutterAudioOutputPlugin.swift
+++ b/ios/Classes/SwiftFlutterAudioOutputPlugin.swift
@@ -31,6 +31,10 @@ public class SwiftFlutterAudioOutputPlugin: NSObject, FlutterPlugin {
         else if(call.method == "changeToBluetooth"){
             result(changeToBluetooth())
         }
+        else if(call.method == "release"){
+            // Avoid changing the shared AVAudioSession; release has no iOS side effects.
+            result(nil)
+        }
         else if(call.method == "getPlatformVersion"){
             result("iOS " + UIDevice.current.systemVersion)
         }

--- a/lib/flutter_audio_output.dart
+++ b/lib/flutter_audio_output.dart
@@ -137,6 +137,20 @@ class FlutterAudioOutput {
     }
   }
 
+  /// Releases audio-routing changes made through this plugin.
+  ///
+  /// On Android this cancels an in-flight route change, clears the selected
+  /// communication device (or legacy speakerphone/Bluetooth SCO state), and
+  /// resets any audio mode applied by the plugin. This method has no effect on
+  /// iOS.
+  static Future<void> release() async {
+    try {
+      await _channel.invokeMethod<void>('release');
+    } on PlatformException catch (e) {
+      throw Exception('Failed to release audio routing: ${e.message}');
+    }
+  }
+
   /// Sets a listener for audio input changes
   static void setListener(void Function() onInputChanged) {
     _onInputChanged = onInputChanged;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_audio_output
 description: A Flutter package flutter_audio_output is to adapt music output.
-version: 1.0.7
+version: 1.1.0
 homepage: https://github.com/itsmurphy/flutter_audio_output.git
 
 environment:

--- a/test/flutter_audio_output_test.dart
+++ b/test/flutter_audio_output_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_audio_output/flutter_audio_output.dart';
 import 'package:flutter_audio_output/flutter_audio_output_platform_interface.dart';
@@ -12,8 +13,17 @@ class MockFlutterAudioOutputPlatform
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final FlutterAudioOutputPlatform initialPlatform =
       FlutterAudioOutputPlatform.instance;
+  const channel = MethodChannel('flutter_audio_output');
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    FlutterAudioOutputPlatform.instance = initialPlatform;
+  });
 
   test('$MethodChannelFlutterAudioOutput is the default instance', () {
     expect(initialPlatform, isInstanceOf<MethodChannelFlutterAudioOutput>());
@@ -44,5 +54,33 @@ void main() {
     const input = AudioInput('Speaker', 2);
     expect(
         input.toString(), 'AudioInput(name: Speaker, port: AudioPort.speaker)');
+  });
+
+  test('release completes through the method channel', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      expect(call.method, 'release');
+      return null;
+    });
+
+    await expectLater(FlutterAudioOutput.release(), completes);
+  });
+
+  test('release wraps platform errors', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      throw PlatformException(code: 'release_failed', message: 'boom');
+    });
+
+    await expectLater(
+      FlutterAudioOutput.release(),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('Failed to release audio routing: boom'),
+        ),
+      ),
+    );
   });
 }


### PR DESCRIPTION
Modern Android applies communication-device routing asynchronously, while the plugin previously completed requests before the route was confirmed. This could make consumers resume playback too early or leave
  routing state behind after failures.

  This PR:

  - Waits for Android route confirmation before completing requests.
  - Handles timeouts, exceptions, disconnected devices, and superseded requests.
  - Restores prior plugin-owned routing state on failure without adopting system-owned routes.
  - Adds a scoped `release()` API for relinquishing routing state acquired by the plugin.
  - Performs mandatory cleanup when the plugin detaches.
  - Keeps `release()` a safe no-op on iOS without deactivating the shared `AVAudioSession`.
  - Runs the Android native test suite once in CI.
  - Updates documentation and prepares version 1.1.0.

  The example app, media-routing policy, and audio-attribute behavior remain unchanged.

  ## Testing

  - `flutter analyze`
  - `flutter test`
  - Android native unit tests
  - Formatting and diff checks